### PR TITLE
Enable Vite build sourcemaps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,11 @@ export default defineConfig({
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-dokumentarkiv",
   },
+  vite: {
+    build: {
+      sourcemap: true,
+    },
+  },
   integrations: [react()],
   logger: {
     entrypoint: "@navikt/astro-logger",


### PR DESCRIPTION
Adds `vite.build.sourcemap: true` to the Astro config so that source maps are emitted during production builds. This makes it easier to debug minified bundles in tools like Sentry or browser devtools.