### PR TITLE
Remove unnecessary defineMiddleware wrapper

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,10 @@
 import { authenticate } from "@navikt/astro-auth";
-import { defineMiddleware, sequence } from "astro/middleware";
+import { sequence } from "astro/middleware";
 import { defaultLocaleRedirect } from "@src/utils/server/locale";
 
 export const onRequest = sequence(
   authenticate(),
-  defineMiddleware(async (context, next) => {
+  async (context, next) => {
     const localeRedirect = defaultLocaleRedirect(context);
 
     if (localeRedirect) {
@@ -12,5 +12,5 @@ export const onRequest = sequence(
     }
 
     return next();
-  }),
+  },
 );


### PR DESCRIPTION
`defineMiddleware` is a type-inference helper that adds no runtime behavior. Since `sequence()` already provides correct types for the middleware function parameters, the wrapper is redundant and can be removed to simplify the code.