### PR TITLE
chore: remove compressHTML config from astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,10 +5,6 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   base: "/dokumentarkiv",
-  // Astro 7 changed the default to 'jsx', which strips spaces between inline
-  // elements. Pin to HTML-aware compression to keep rendered output identical
-  // to Astro 5 (no whitespace regressions in user-facing Norwegian copy).
-  compressHTML: true,
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-dokumentarkiv",
   },


### PR DESCRIPTION
Removes the `compressHTML: true` option and its associated comment from `astro.config.mjs`. This configuration is no longer needed.