### PR TITLE
Use Chainguard Node 24 runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim@sha256:8b0b8c0d78166534d392bfb670f96fa6d443cec16169481788aa1ed27dfc4a7d
 
 WORKDIR usr/src/app
 COPY ./dist ./dist


### PR DESCRIPTION
Replace the Google distroless runtime with Nav's pinned Chainguard Node 24 slim image, matching the runtime setup used by `tms-utkast-frontend`.